### PR TITLE
rtsp.js doesn't correctly handle some SETUP requests

### DIFF
--- a/lib/rtsp.js
+++ b/lib/rtsp.js
@@ -38,7 +38,7 @@ RtspServer.prototype.connectHandler = function(socket) {
   var parser = new Parser(socket);
   parser.on('message', function(m) {
     var response = new tools.MessageBuilder(socket);
-    this.methodMapping[m.method](response, m.headers, m.content);
+    this.methodMapping[m.method.replace(/[\n\r]/, '')](response, m.headers, m.content);
   }.bind(this));
 
   socket.on('close', this.disconnectHandler.bind(this));


### PR DESCRIPTION
Using Airsonos I saw a SETUP request hit RtspServer.connectHandler which had a leading carriage return

```
SETUP rtsp://192.168.1.27/4932615128151379837 RTSP/1.0
Transport: RTP/AVP/UDP;unicast;mode=record;timing_port=52230;x-events;control_port=55038
CSeq: 3
X-Apple-Device-ID: 0x4db5642d294
DACP-ID: <snip>
Active-Remote: <snip>
User-Agent: AirPlay/200.54
```

This caused this error

``` /usr/local/lib/node_modules/airsonos/node_modules/nodetunes/lib/rtsp.js:41
this.methodMappingm.method;
^
TypeError: Property '
SETUP' of object # is not a function
at RtspServer.connectHandler (/usr/local/lib/node_modules/airsonos/node_modules/nodetunes/lib/rtsp.js:41:33)
at EventEmitter.emit (events.js:95:17)
at Socket.Parser (/usr/local/lib/node_modules/airsonos/node_modules/nodetunes/node_modules/httplike/index.js:61:11)
at Socket.EventEmitter.emit (events.js:95:17)
at Socket. (stream_readable.js:746:14)
at Socket.EventEmitter.emit (events.js:92:17)
at emitReadable (_stream_readable.js:408:10)
at emitReadable (_stream_readable.js:404:5)
at readableAddChunk (_stream_readable.js:165:9)
at Socket.Readable.push (_stream_readable.js:127:10)
```
