### PR TITLE
Use a buffered stream to improve playback quality

### DIFF
--- a/lib/rtspmethods.js
+++ b/lib/rtspmethods.js
@@ -6,6 +6,7 @@ var dgram = require('dgram');
 var randomstring = require('randomstring');
 var crypto = require('crypto');
 var stream = require('stream');
+var BufferStream = require('bufferstream');
 
 module.exports = function(rtspServer) {
 
@@ -94,7 +95,7 @@ module.exports = function(rtspServer) {
     rtspServer.clientName = sdp.i;
 
     rtspServer.clientConnected = res.socket;
-    rtspServer.outputStream = new stream.PassThrough();
+    rtspServer.outputStream = new BufferStream([{size:'flexible'}]);
     rtspServer.external.emit('clientConnected', rtspServer.outputStream);
 
     res.send();

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "randomstring": "1.0.3",
     "httplike": "0.0.8",
     "random-mac": "0.0.4",
-    "metricstream": "0.0.0"
+    "metricstream": "0.0.0",
+    "bufferstream": "0.6.2"
   },
   "devDependencies": {
     "speaker": "0.2.1",


### PR DESCRIPTION
Uses a buffered stream instead of a passthrough stream. Prevents gaps in the audio and this warning:

> Didn't have any audio data in callback (buffer underflow)