### PR TITLE
Added ip address option handling

### DIFF
--- a/lib/rtspmethods.js
+++ b/lib/rtspmethods.js
@@ -22,7 +22,7 @@ module.exports = function(rtspServer) {
       // encrypted with the ApEx private key (private encryption mode w/ PKCS1 padding)
 
       var challengeBuf = new Buffer(req.getHeader('Apple-Challenge'), 'base64');
-      var ipAddr = new Buffer(ip.toBuffer(ip.address()), 'hex');
+      var ipAddr = new Buffer(ip.toBuffer(rtspServer.options.ipAddress || ip.address()), 'hex');
       var macAddr = new Buffer(rtspServer.macAddress.replace(/:/g, ''), 'hex');
       res.set('Apple-Response', tools.generateAppleResponse(challengeBuf, ipAddr, macAddr));
     }


### PR DESCRIPTION
I added the ability to pass in an ip address to bind to instead of relying on ip.address(). This was used to solve airsonos issue 27.