### PR TITLE
Apple challenge not accepted in node 0.12.*

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -7,7 +7,7 @@ var speaker = new Speaker({
   bitDepth: 16,
   sampleRate: 44100
 });
-var server = new AirTunesServer({ serverName: 'NodeTunes Speaker'});
+var server = new AirTunesServer({ serverName: 'NodeTunes Speaker', verbose: process.env.VERBOSE});
 
 server.on('clientConnected', function(stream) {
 	stream.pipe(speaker);


### PR DESCRIPTION
I can't seem to get the server working in iOS 8. When I select the server, the airplay icon lights up, however as soon as I play some music, the icon goes dark. It appears from the logs that the challenge fails. Any ideas I can try? I'd love to get this working.

Log output:
```
Sams-MacBook-Air:nodetunes sberan$ VERBOSE=true node examples/server.js 
  nodetunes:server starting nodetunes server (NodeTunes Speaker) +0ms
  nodetunes:server broadcasting mdns advertisement (for port 5000) +17ms
  nodetunes:rtsp received method OPTIONS (CSeq: 0)
{ cseq: '0',
  'x-apple-device-id': '0x908d6c8ff831',
  'apple-challenge': 'geAmzg+SIko0K+iAhEfjAQ==',
  'dacp-id': '9F0529BC9FE0587F',
  'active-remote': '3767354429',
  'user-agent': 'AirPlay/220.68',
  'content-length': '0' } +13s
  nodetunes:helper building challenge for geAmzg+SIko0K+iAhEfjAQ== (ip: c0a8010e, mac: 545200c38b16) +2ms
  nodetunes:helper computed challenge: cbI20wYa2Q1crxCPx7p43L1/lrZmIeca1bnarskXHt6Y1NVrDgddEOK5lGM+wFYQ0T51KNYDu8hS6G7yM0opok+pWz6hhNQhXuXoMDrZFClhVZuniqHpx+r7Guq6TEbVxHKjjlsguBWfMm/GNts/zyKUcPDMvFDd4zIIF+ung9upnXMEprVmaaU4kw/NGf04mfXmWIhgcmz494jELlZ5hdISH+PEbf0SdY4JOiFE1resAPe7amVI9waSYlfEH1V7LlbHdwQfAaJ3uh8pS75dPLfrH6KZs6AFQTXZte8LGTLUgrrbofJd/Xc6qM9ZhOEpd30Q0b6tMzx5C3vx3YVBfQ== +68ms
```