### PR TITLE
Add DAAP library to extend content type support.

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -30,46 +30,6 @@ var parseSdp = function(msg) {
   return output;
 };
 
-var dmapTypes = {
-  mper: 8,
-  asal: 'str',
-  asar: 'str',
-  ascp: 'str',
-  asgn: 'str',
-  minm: 'str',
-  astn: 2,
-  asdk: 1,
-  caps: 1,
-  astm: 4,
-};
-
-var parseDmap = function(buffer) {
-  var output = {};
-
-  for (var i = 8; i < buffer.length;) {
-    var itemType = buffer.slice(i, i + 4);
-    var itemLength = buffer.slice(i + 4, i + 8).readUInt32BE(0);
-    if (itemLength !== 0) {
-      var data = buffer.slice(i + 8, i + 8 + itemLength);
-      if (dmapTypes[itemType] == 'str') {
-        output[itemType.toString()] = data.toString();
-      } else if (dmapTypes[itemType] == 1) {
-        output[itemType.toString()] = data.readUInt8(0);
-      } else if (dmapTypes[itemType] == 2) {
-        output[itemType.toString()] = data.readUInt16BE(0);
-      } else if (dmapTypes[itemType] == 4) {
-        output[itemType.toString()] = data.readUInt32BE(0);
-      } else if (dmapTypes[itemType] == 8) {
-        output[itemType.toString()] = (data.readUInt32BE(0) << 8) + data.readUInt32BE(4);
-      }
-    }
-
-    i += 8 + itemLength;
-  }
-
-  return output;
-};
-
 var getPrivateKey = function() {
 
   var keyFile = fs.readFileSync(__dirname + '/../private.key');
@@ -152,7 +112,6 @@ var decryptAudioData = function(data, audioAesKey, audioAesIv, headerSize) {
 module.exports.decryptAudioData = decryptAudioData;
 module.exports.getDecoderOptions = getDecoderOptions;
 module.exports.parseSdp = parseSdp;
-module.exports.parseDmap = parseDmap;
 module.exports.generateAppleResponse = generateAppleResponse;
 module.exports.generateRfc2617Response = generateRfc2617Response;
 module.exports.rsaPrivateKey = privateKey;

--- a/lib/rtspmethods.js
+++ b/lib/rtspmethods.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var tools = require('./helper');
+var daap = require('node-daap');
 var ipaddr = require('ipaddr.js');
 var randomstring = require('randomstring');
 var crypto = require('crypto');
@@ -200,7 +201,7 @@ module.exports = function(rtspServer) {
     if (req.getHeader('Content-Type') == 'application/x-dmap-tagged') {
 
       // metadata dmap/daap format
-      var dmapData = tools.parseDmap(req.content);
+      var dmapData = daap.decode(req.content);
       rtspServer.metadata = dmapData;
       rtspServer.external.emit('metadataChange', rtspServer.metadata);
       debug('received metadata (%s)', JSON.stringify(rtspServer.metadata));

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ipaddr.js": "^1.0.1",
     "mdns": "^2.2.10",
     "metricstream": "0.0.0",
+    "node-daap": "^1.0.2",
     "node-forge": "^0.6.16",
     "portastic": "0.0.1",
     "priorityqueuejs": "0.2.0",

--- a/test/rtspmethods.test.js
+++ b/test/rtspmethods.test.js
@@ -1,5 +1,6 @@
 var net = require('net');
 var assert = require('assert');
+var daap = require('node-daap');
 var Nodetunes = require('../index');
 var Parser = require('httplike').ClientParser;
 var helper = require('../lib/helper');
@@ -295,29 +296,18 @@ describe('RTSP Methods', function() {
 
     });
 
-    it('should set and acknowedge text metadata (TODO)', function(done) {
+    it('handles "metadataChange"', function(done) {
+      server.on('metadataChange', function(data){
+        assert.equal(data.asal, "Album Name");
+        assert.equal(data.asar, "Artist");
+        assert.equal(data.minm, "Track Name");
+        done()
+      })
 
-      parser.on('message', function(m) {
-        assert(m.statusCode === 200);
-        done();
-      });
-
-      var content = 'bawkbawk';
-
-      client.connect(port, 'localhost', function() {
-        client.write('SET_PARAMETER * RTSP/1.0\r\nCSeq:2\r\nUser-Agent: AirPlay/190.9\r\nContent-Type:application/x-dmap-tagged\r\nContent-Length:' + content.length + '\r\n\r\n' + content);
-      });
-
-    });
-
-    it('should set and acknowedge album metadata (TODO)', function(done) {
-
-      parser.on('message', function(m) {
-        assert(m.statusCode === 200);
-        done();
-      });
-
-      var content = 'bawkbawk';
+      var name = daap.encode('minm', 'Track Name')
+      var artist = daap.encode('asar', 'Artist')
+      var album = daap.encode('asal', 'Album Name')
+      var content = daap.encodeList('mlit', name, artist, album)
 
       client.connect(port, 'localhost', function() {
         client.write('SET_PARAMETER * RTSP/1.0\r\nCSeq:2\r\nUser-Agent: AirPlay/190.9\r\nContent-Type:application/x-dmap-tagged\r\nContent-Length:' + content.length + '\r\n\r\n' + content);


### PR DESCRIPTION
I extracted the encoding/decoding of DAAP messages into its own libary called [node-daap](http://github.com/kylewelsby/daap) that includes all found content types for DAAP.
