### PR TITLE
Extend onMetaChange response data

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -14,4 +14,18 @@ server.on('clientConnected', function(stream) {
   stream.pipe(speaker);
 });
 
+/**
+* Uses Protocol Codes - not so human readable
+server.on('metadataChange', function (metadata) {
+  console.log(JSON.stringify(metadata, null, "    "));
+})
+*/
+
+/**
+* Uses DAAP Names for keys - human readable
+server.on('metadataChangePretty', function (metadata) {
+  console.log(JSON.stringify(metadata, null, "    "));
+})
+*/
+
 server.start();

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -30,46 +30,6 @@ var parseSdp = function(msg) {
   return output;
 };
 
-var dmapTypes = {
-  mper: 8,
-  asal: 'str',
-  asar: 'str',
-  ascp: 'str',
-  asgn: 'str',
-  minm: 'str',
-  astn: 2,
-  asdk: 1,
-  caps: 1,
-  astm: 4,
-};
-
-var parseDmap = function(buffer) {
-  var output = {};
-
-  for (var i = 8; i < buffer.length;) {
-    var itemType = buffer.slice(i, i + 4);
-    var itemLength = buffer.slice(i + 4, i + 8).readUInt32BE(0);
-    if (itemLength !== 0) {
-      var data = buffer.slice(i + 8, i + 8 + itemLength);
-      if (dmapTypes[itemType] == 'str') {
-        output[itemType.toString()] = data.toString();
-      } else if (dmapTypes[itemType] == 1) {
-        output[itemType.toString()] = data.readUInt8(0);
-      } else if (dmapTypes[itemType] == 2) {
-        output[itemType.toString()] = data.readUInt16BE(0);
-      } else if (dmapTypes[itemType] == 4) {
-        output[itemType.toString()] = data.readUInt32BE(0);
-      } else if (dmapTypes[itemType] == 8) {
-        output[itemType.toString()] = (data.readUInt32BE(0) << 8) + data.readUInt32BE(4);
-      }
-    }
-
-    i += 8 + itemLength;
-  }
-
-  return output;
-};
-
 var getPrivateKey = function() {
 
   var keyFile = fs.readFileSync(__dirname + '/../private.key');
@@ -152,7 +112,6 @@ var decryptAudioData = function(data, audioAesKey, audioAesIv, headerSize) {
 module.exports.decryptAudioData = decryptAudioData;
 module.exports.getDecoderOptions = getDecoderOptions;
 module.exports.parseSdp = parseSdp;
-module.exports.parseDmap = parseDmap;
 module.exports.generateAppleResponse = generateAppleResponse;
 module.exports.generateRfc2617Response = generateRfc2617Response;
 module.exports.rsaPrivateKey = privateKey;

--- a/lib/rtspmethods.js
+++ b/lib/rtspmethods.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var tools = require('./helper');
+var daap = require('node-daap');
 var ipaddr = require('ipaddr.js');
 var randomstring = require('randomstring');
 var crypto = require('crypto');
@@ -200,7 +201,7 @@ module.exports = function(rtspServer) {
     if (req.getHeader('Content-Type') == 'application/x-dmap-tagged') {
 
       // metadata dmap/daap format
-      var dmapData = tools.parseDmap(req.content);
+      var dmapData = daap.decode(req.content);
       rtspServer.metadata = dmapData;
       rtspServer.external.emit('metadataChange', rtspServer.metadata);
       debug('received metadata (%s)', JSON.stringify(rtspServer.metadata));

--- a/lib/rtspmethods.js
+++ b/lib/rtspmethods.js
@@ -204,6 +204,7 @@ module.exports = function(rtspServer) {
       var dmapData = daap.decode(req.content);
       rtspServer.metadata = dmapData;
       rtspServer.external.emit('metadataChange', rtspServer.metadata);
+      rtspServer.external.emit('metadataChangePretty', daap.decode(req.content, true));
       debug('received metadata (%s)', JSON.stringify(rtspServer.metadata));
 
     } else if (req.getHeader('Content-Type') == 'image/jpeg') {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ipaddr.js": "^1.0.1",
     "mdns": "^2.2.10",
     "metricstream": "0.0.0",
+    "node-daap": "^1.0.2",
     "node-forge": "^0.6.16",
     "portastic": "0.0.1",
     "priorityqueuejs": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ipaddr.js": "^1.0.1",
     "mdns": "^2.2.10",
     "metricstream": "0.0.0",
-    "node-daap": "^1.0.2",
+    "node-daap": "^1.0.3",
     "node-forge": "^0.6.16",
     "portastic": "0.0.1",
     "priorityqueuejs": "0.2.0",

--- a/test/rtspmethods.test.js
+++ b/test/rtspmethods.test.js
@@ -1,5 +1,6 @@
 var net = require('net');
 var assert = require('assert');
+var daap = require('node-daap');
 var Nodetunes = require('../index');
 var Parser = require('httplike').ClientParser;
 var helper = require('../lib/helper');
@@ -295,29 +296,18 @@ describe('RTSP Methods', function() {
 
     });
 
-    it('should set and acknowedge text metadata (TODO)', function(done) {
+    it('handles "metadataChange"', function(done) {
+      server.on('metadataChange', function(data){
+        assert.equal(data.asal, "Album Name");
+        assert.equal(data.asar, "Artist");
+        assert.equal(data.minm, "Track Name");
+        done()
+      })
 
-      parser.on('message', function(m) {
-        assert(m.statusCode === 200);
-        done();
-      });
-
-      var content = 'bawkbawk';
-
-      client.connect(port, 'localhost', function() {
-        client.write('SET_PARAMETER * RTSP/1.0\r\nCSeq:2\r\nUser-Agent: AirPlay/190.9\r\nContent-Type:application/x-dmap-tagged\r\nContent-Length:' + content.length + '\r\n\r\n' + content);
-      });
-
-    });
-
-    it('should set and acknowedge album metadata (TODO)', function(done) {
-
-      parser.on('message', function(m) {
-        assert(m.statusCode === 200);
-        done();
-      });
-
-      var content = 'bawkbawk';
+      var name = daap.encode('minm', 'Track Name')
+      var artist = daap.encode('asar', 'Artist')
+      var album = daap.encode('asal', 'Album Name')
+      var content = daap.encodeList('mlit', name, artist, album)
 
       client.connect(port, 'localhost', function() {
         client.write('SET_PARAMETER * RTSP/1.0\r\nCSeq:2\r\nUser-Agent: AirPlay/190.9\r\nContent-Type:application/x-dmap-tagged\r\nContent-Length:' + content.length + '\r\n\r\n' + content);


### PR DESCRIPTION
I have taken the liberty of building a library that decodes the `application/x-dmap-tagged` response and converts the content into a manageable JSON response. Its called [node-daap](https://github.com/kylewelsby/daap).

There are now two verities. `metadataChange` which retains backwards compatibility but with more content. and `metadataChangePretty` which changes the key's to human readable names.

example.

```
{
    "dmap.itemkind": 2,
    "daap.songalbum": "Beat Tape 2",
    "daap.songartist": "Tom Misch",
    "daap.songbitrate": 256,
    "daap.songcompilation": 0,
    "dmap.itemdateadded": 1447281526,
    "daap.songdateadded": 1447281526,
    "dmap.itemdateplayed": 1447528517,
    "daap.songdateplayed": 1447528517,
    "daap.songdatemodified": 1447281587,
    "daap.songdisccount": 1,
    "daap.songdiscnumber": 1,
    "daap.songgenre": "Alternative",
    "daap.songdescription": "Purchased AAC audio file",
    "daap.songrelativevolume": 0,
    "daap.songsamplerate": 44100,
    "daap.songsize": 9194382,
    "daap.songstarttime ": 0,
    "daap.songstoptime ": 0,
    "daap.songtime": 257328,
    "daap.songtrackcount": 12,
    "daap.songtracknumber": 7,
    "daap.songuserrating": 0,
    "daap.songyear": 2015,
    "daap.songformat": "m4a",
    "dmap.itemid": 25588,
    "dmap.itemname": "Come Back",
    "dmap.persistentid": 7136977865545740000,
    "daap.songdisabled": 0,
    "com.apple.itunes.norm-volume": 1305,
    "daap.songdatakind": 0,
    "daap.songsbeatsperminute": 0,
    "daap.songcodectype": 1836069985,
    "daap.songcodecsubtype": 2,
    "com.apple.itunes.is-podcast": 0,
    "daap.songcontentrating": 0,
    "com.apple.itunes.has-video": 0,
    "com.apple.itunes.mediakind": 1,
    "com.apple.itunes.episode-sort": 0,
    "com.apple.itunes.season-num": 0,
    "com.apple.itunes.gapless-heur": 1,
    "com.apple.itunes.gapless-enc-dr": 730,
    "com.apple.itunes.gapless-dur": 11348198,
    "com.apple.itunes.gapless-resy": 0,
    "com.apple.itunes.gapless-enc-del": 2112,
    "daap.songalbumartist": "Tom Misch",
    "daap.songgapless": 0,
    "dmap.objectextradata": 1,
    "daap.songextradata": 1,
    "daap.songhasbeenplayed": 1,
    "daap.sortname": "Come Back",
    "daap.sortartist": "Tom Misch",
    "daap.sortalbum": "Beat Tape 2",
    "daap.bookmarkable": 0,
    "daap.songalbumid": -5712788265707270000,
    "daap.songlongsize": 9194382,
    "com.apple.itunes.store-pers-id": 1023678734,
    "com.apple.itunes.drm-versions": 0,
    "com.apple.itunes.drm-platform-id": 0,
    "com.apple.itunes.drm-user-id": 0,
    "com.apple.itunes.non-drm-user-id": 171200441,
    "com.apple.itunes.drm-key1-id": 0,
    "com.apple.itunes.drm-key2-id": 0,
    "com.apple.itunes.drm-downloader-user-id": 0,
    "com.apple.itunes.drm-family-id": 0,
    "com.apple.itunes.xid": "AWALUK:isrc:GBWWP1501117",
    "com.apple.itunes.extended-media-kind": 0,
    "com.apple.itunes.movie-info-xml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n\t<key>asset-info</key>\n\t<dict>\n\t\t<key>file-size</key>\n\t\t<integer>9194382</integer>\n\t\t<key>flavor</key>\n\t\t<string>2:256</string>\n\t</dict>\n</dict>\n</plist>\n",
    "daap.songuserplaycount": 1,
    "daap.songartistid": -6588044044045134000,
    "com.apple.itunes.artworkchecksum": 91252,
    "daap.songuserskipcount": 0,
    "daap.songlastskipdate": -2082844800,
    "dmap.downloadstatus": 1,
    "daap.songexcludefromshuffle": 0,
    "daap.songuserratingstatus": 0,
    "daap.songalbumuserrating": 0,
    "daap.songalbumuserratingstatus": 32,
    "com.apple.itunes.can-be-genius-seed": 1,
    "com.apple.itunes.liked-state": 0,
    "com.apple.itunes.store.album-liked-state": 0
}
```
