### PR TITLE
Use start/stop interface on mDNS to correctly stop servers

### DIFF
--- a/lib/rtsp.js
+++ b/lib/rtsp.js
@@ -30,7 +30,6 @@ function RtspServer(options, external) {
 }
 
 RtspServer.prototype.connectHandler = function(socket) {
-
   if (this.handling && !this.clientConnected) {
     socket.end();
     return;
@@ -96,5 +95,9 @@ RtspServer.prototype.disconnectHandler = function() {
   }
 
 };
+
+RtspServer.prototype.stop = function() {
+  this.rtp.stop()
+}
 
 module.exports = RtspServer;

--- a/lib/server.js
+++ b/lib/server.js
@@ -46,7 +46,6 @@ function NodeTunes(options) {
 
   this.netServer = null;
   this.rtspServer = new RtspServer(this.options, this);
-
 }
 
 util.inherits(NodeTunes, EventEmitter);
@@ -69,11 +68,11 @@ NodeTunes.prototype.start = function(callback) {
     }
 
     this.netServer = net.createServer(this.rtspServer.connectHandler.bind(this.rtspServer)).listen(port, function() {
-
-      var ad = mdns.createAdvertisement(mdns.tcp('raop'), port, {
+      this.advertisement = mdns.createAdvertisement(mdns.tcp('raop'), port, {
         name: this.options.macAddress + '@' + this.options.serverName,
         txtRecord: this.txtSetup,
       });
+      this.advertisement.start()
 
       if (callback) {
         callback(null, {
@@ -93,6 +92,8 @@ NodeTunes.prototype.start = function(callback) {
 NodeTunes.prototype.stop = function() {
   debug('stopping nodetunes server');
   this.netServer.close();
+  this.rtspServer.stop();
+  this.advertisement.stop();
 };
 
 module.exports = NodeTunes;


### PR DESCRIPTION
This PR correctly starts and stops the DNS server that advertises Sonos devices. Prior to this PR, if a `Nodetunes` instance was stopped, the DNS would continue to be broadcasted. 
