### PR TITLE
Catch undefined client address bug

### DIFF
--- a/lib/rtspmethods.js
+++ b/lib/rtspmethods.js
@@ -25,7 +25,15 @@ module.exports = function(rtspServer) {
 
       var challengeBuf = new Buffer(req.getHeader('Apple-Challenge'), 'base64');
 
-      var ipAddrRepr = ipaddr.parse(rtspServer.socket.address().address);
+      function getRemoteAddr (rtspServer) {
+        if (rtspServer.socket.address().address) {
+          return ipaddr.parse(rtspServer.socket.address().address);
+        } else {
+          return ipAddr.parse('127.0.0.1');
+        }
+      };
+      
+      var ipAddrRepr = getRemoteAddr(rtspServer);
       if (ipAddrRepr.kind() === 'ipv6' && ipAddrRepr.isIPv4MappedAddress()) {
         ipAddrRepr = ipAddrRepr.toIPv4Address();
       }


### PR DESCRIPTION
Checks that the client address variable of `socket` is set, and returns loopback interface if it isn't. Hacky, but hey, until someone fixes this https://github.com/nodejs/node-v0.x-archive/issues/7566, blame node.js :)